### PR TITLE
Blocks for built-ins

### DIFF
--- a/addons/block_code/types/types.gd
+++ b/addons/block_code/types/types.gd
@@ -8,6 +8,7 @@ enum BlockType {
 	# Parameters
 	STRING,
 	INT,
+	FLOAT,
 	VECTOR2,
 	BOOL,
 	NODE

--- a/addons/block_code/ui/blocks/basic_block/basic_block.tscn
+++ b/addons/block_code/ui/blocks/basic_block/basic_block.tscn
@@ -32,6 +32,7 @@ layout_mode = 2
 mouse_filter = 1
 script = ExtResource("2_iwx12")
 color = Color(0.530082, 0.933559, 0.726557, 1)
+outline_color = Color(0.424066, 0.746847, 0.581246, 1)
 show_top = false
 
 [node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("2_r14pb")]
@@ -40,10 +41,10 @@ layout_mode = 2
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TopMarginContainer"]
 layout_mode = 2
 mouse_filter = 2
-theme_override_constants/margin_left = 4
-theme_override_constants/margin_top = 4
-theme_override_constants/margin_right = 4
-theme_override_constants/margin_bottom = 4
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 6
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TopMarginContainer/MarginContainer"]
 custom_minimum_size = Vector2(200, 0)

--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -97,7 +97,7 @@ func format():
 	for i in block_formats.size():
 		var row := MarginContainer.new()
 		row.name = "Row%d" % i
-		row.custom_minimum_size.x = 100
+		row.custom_minimum_size.x = 80
 		row.custom_minimum_size.y = 30
 		row.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 
@@ -117,10 +117,10 @@ func format():
 
 		var row_hbox_container := MarginContainer.new()
 		row_hbox_container.name = "RowHBoxContainer"
-		row_hbox_container.add_theme_constant_override("margin_left", 4)
-		row_hbox_container.add_theme_constant_override("margin_right", 4)
-		row_hbox_container.add_theme_constant_override("margin_top", 4)
-		row_hbox_container.add_theme_constant_override("margin_bottom", 4)
+		row_hbox_container.add_theme_constant_override("margin_left", 10)
+		row_hbox_container.add_theme_constant_override("margin_right", 6)
+		row_hbox_container.add_theme_constant_override("margin_top", 12)
+		row_hbox_container.add_theme_constant_override("margin_bottom", 6)
 		row_hbox_container.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		row.add_child(row_hbox_container)
 

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -17,6 +17,7 @@ func _ready():
 
 	var new_panel = _panel.get_theme_stylebox("panel").duplicate()
 	new_panel.bg_color = color
+	new_panel.border_color = color.darkened(0.2)
 	_panel.add_theme_stylebox_override("panel", new_panel)
 
 	format()

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qxoc2"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0b52j"]
 bg_color = Color(1, 1, 1, 1)
 border_width_left = 4
 border_width_top = 4
@@ -26,7 +26,7 @@ block_type = 3
 [node name="Panel" type="Panel" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_qxoc2")
+theme_override_styles/panel = SubResource("StyleBoxFlat_0b52j")
 
 [node name="DragDropArea" parent="." instance=ExtResource("2_gy5co")]
 layout_mode = 2

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -3,15 +3,18 @@
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ronte"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qxoc2"]
 bg_color = Color(1, 1, 1, 1)
-corner_radius_top_left = 40
-corner_radius_top_right = 40
-corner_radius_bottom_right = 40
-corner_radius_bottom_left = 40
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
 
 [node name="ParameterBlock" type="MarginContainer"]
-custom_minimum_size = Vector2(100, 0)
 offset_right = 16.0
 offset_bottom = 8.0
 size_flags_horizontal = 0
@@ -23,7 +26,7 @@ block_type = 3
 [node name="Panel" type="Panel" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_ronte")
+theme_override_styles/panel = SubResource("StyleBoxFlat_qxoc2")
 
 [node name="DragDropArea" parent="." instance=ExtResource("2_gy5co")]
 layout_mode = 2
@@ -32,10 +35,10 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 0
 mouse_filter = 2
-theme_override_constants/margin_left = 8
-theme_override_constants/margin_top = 4
-theme_override_constants/margin_right = 8
-theme_override_constants/margin_bottom = 4
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 8
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
 unique_name_in_owner = true

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -31,6 +31,7 @@ layout_mode = 2
 mouse_filter = 1
 script = ExtResource("2_lctqt")
 color = Color(1, 1, 1, 1)
+outline_color = Color(0.8, 0.8, 0.8, 1)
 
 [node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("2_owgdx")]
 layout_mode = 2
@@ -38,14 +39,14 @@ layout_mode = 2
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TopMarginContainer"]
 layout_mode = 2
 mouse_filter = 2
-theme_override_constants/margin_left = 4
-theme_override_constants/margin_top = 4
-theme_override_constants/margin_right = 4
-theme_override_constants/margin_bottom = 4
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 6
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TopMarginContainer/MarginContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(200, 0)
+custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 0

--- a/addons/block_code/ui/blocks/utilities/background/background.gd
+++ b/addons/block_code/ui/blocks/utilities/background/background.gd
@@ -55,8 +55,7 @@ func float_array_to_Vector2Array(coords: Array) -> PackedVector2Array:
 
 
 func _draw():
-	if outline_color == Color.BLACK:
-		outline_color = color.darkened(0.2)
+	outline_color = color.darkened(0.2)
 
 	var fill_polygon = [[0.0, 0.0]]
 	if show_top:

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -58,6 +58,8 @@ func get_string() -> String:
 
 	if block_type == Types.BlockType.STRING:
 		text = "'%s'" % text
+	if block_type == Types.BlockType.VECTOR2:
+		text = "Vector2(%s)" % text
 
 	return text
 

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -192,3 +192,93 @@ static func add_to_categories(main: Array[BlockCategory], addition: Array[BlockC
 			main.append(add_category)
 
 	return main
+
+
+static func built_in_type_to_block_type(type: Variant.Type):
+	match type:
+		TYPE_BOOL:
+			return Types.BlockType.BOOL
+		TYPE_INT:
+			return Types.BlockType.INT
+		TYPE_FLOAT:
+			return Types.BlockType.FLOAT
+		TYPE_STRING:
+			return Types.BlockType.STRING
+		TYPE_VECTOR2:
+			return Types.BlockType.VECTOR2
+
+	return null
+
+
+static func property_to_blocklist(property: Dictionary) -> Array[Block]:
+	var block_list: Array[Block] = []
+
+	var block_type = built_in_type_to_block_type(property.type)
+
+	if block_type:
+		var type_string: String = Types.BlockType.find_key(block_type)
+
+		var b = BLOCKS["statement_block"].instantiate()
+		b.block_format = "Set %s {value: %s}" % [property.name, type_string]
+		b.statement = "%s = {value}" % property.name
+		block_list.append(b)
+
+		b = BLOCKS["parameter_block"].instantiate()
+		b.block_type = block_type
+		b.block_format = "%s" % property.name
+		b.statement = "%s" % property.name
+		block_list.append(b)
+
+	return block_list
+
+
+static func category_from_property_list(property_list: Array, selected_props: Array, p_name: String, p_color: Color) -> BlockCategory:
+	var block_list: Array[Block]
+
+	for selected_property in selected_props:
+		var found_prop
+		for prop in property_list:
+			if selected_property == prop.name:
+				found_prop = prop
+				break
+		block_list.append_array(property_to_blocklist(found_prop))
+
+	return BlockCategory.new(p_name, block_list, p_color)
+
+
+static func get_inherited_categories(_class_name: String) -> Array[BlockCategory]:
+	var cats: Array[BlockCategory] = []
+
+	var current: String = _class_name
+
+	while current != "":
+		add_to_categories(cats, get_built_in_categories(current))
+		current = ClassDB.get_parent_class(current)
+
+	return cats
+
+
+static func get_built_in_categories(_class_name: String) -> Array[BlockCategory]:
+	var cats: Array[BlockCategory] = []
+
+	var props: Array = []
+	var block_list: Array[Block] = []
+
+	match _class_name:
+		"Node2D":
+			var b = BLOCKS["statement_block"].instantiate()
+			b.block_format = "Set rotation degrees {angle: FLOAT}"
+			b.statement = "rotation = deg_to_rad({angle})"
+			block_list.append(b)
+
+			props = ["position", "rotation"]
+
+	var prop_list = ClassDB.class_get_property_list(_class_name, true)
+
+	var class_cat: BlockCategory = category_from_property_list(prop_list, props, _class_name, Color.SLATE_GRAY)
+	block_list.append_array(class_cat.block_list)
+	class_cat.block_list = block_list
+	if props.size() > 0:
+		cats.append(class_cat)
+
+	return cats

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -219,13 +219,18 @@ static func property_to_blocklist(property: Dictionary) -> Array[Block]:
 		var type_string: String = Types.BlockType.find_key(block_type)
 
 		var b = BLOCKS["statement_block"].instantiate()
-		b.block_format = "Set %s {value: %s}" % [property.name, type_string]
+		b.block_format = "Set %s {value: %s}" % [property.name.capitalize(), type_string]
 		b.statement = "%s = {value}" % property.name
+		block_list.append(b)
+
+		b = BLOCKS["statement_block"].instantiate()
+		b.block_format = "Change %s by {value: %s}" % [property.name.capitalize(), type_string]
+		b.statement = "%s += {value}" % property.name
 		block_list.append(b)
 
 		b = BLOCKS["parameter_block"].instantiate()
 		b.block_type = block_type
-		b.block_format = "%s" % property.name
+		b.block_format = "%s" % property.name.capitalize()
 		b.statement = "%s" % property.name
 		block_list.append(b)
 
@@ -267,11 +272,11 @@ static func get_built_in_categories(_class_name: String) -> Array[BlockCategory]
 	match _class_name:
 		"Node2D":
 			var b = BLOCKS["statement_block"].instantiate()
-			b.block_format = "Set rotation degrees {angle: FLOAT}"
-			b.statement = "rotation = deg_to_rad({angle})"
+			b.block_format = "Set Rotation Degrees {angle: FLOAT}"
+			b.statement = "rotation_degrees = {angle}"
 			block_list.append(b)
 
-			props = ["position", "rotation"]
+			props = ["position", "rotation", "scale"]
 
 	var prop_list = ClassDB.class_get_property_list(_class_name, true)
 

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -15,7 +15,8 @@ func bsd_selected(bsd: BlockScriptData):
 				init_picker(script.get_custom_blocks())
 				return
 
-	init_picker()
+	# Should be built-in class
+	init_picker(CategoryFactory.get_inherited_categories(bsd.script_inherits))
 
 
 func init_picker(extra_blocks: Array[BlockCategory] = []):

--- a/test_game/test_game.tscn
+++ b/test_game/test_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=55 format=3 uid="uid://bbwmxee7ukgul"]
+[gd_scene load_steps=68 format=3 uid="uid://bbwmxee7ukgul"]
 
 [ext_resource type="PackedScene" uid="uid://ddx1cd5q6t61o" path="res://addons/block_code/simple_nodes/simple_character/simple_character.tscn" id="1_hrpwq"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="2_ewral"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://addons/block_code/ui/block_canvas/serialized_block.gd" id="3_dpt5n"]
 [ext_resource type="Script" path="res://addons/block_code/ui/block_canvas/serialized_block_tree_node_array.gd" id="4_xt862"]
 [ext_resource type="Script" path="res://addons/block_code/block_script_data/block_script_data.gd" id="5_q37d3"]
+[ext_resource type="Texture2D" uid="uid://dr8e0tvfxjy1f" path="res://icon.svg" id="7_a27o8"]
 
 [sub_resource type="Resource" id="Resource_vk4g7"]
 script = ExtResource("3_dpt5n")
@@ -107,7 +108,101 @@ func _physics_process(_delta):
 
 "
 
-[sub_resource type="Resource" id="Resource_da88k"]
+[sub_resource type="Resource" id="Resource_2qpq0"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 6], ["position", Vector2(0, 0)], ["block_format", "Is in group {group: STRING}"], ["statement", "is_in_group({group})"], ["param_input_strings", {
+"group": "Enemy"
+}]]
+
+[sub_resource type="Resource" id="Resource_pg8g3"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_2qpq0")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_r00jg"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
+"text": "I am an enemy!"
+}]]
+
+[sub_resource type="Resource" id="Resource_1hfh0"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_r00jg")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_snkb4"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
+"text": "I am not an enemy!"
+}]]
+
+[sub_resource type="Resource" id="Resource_i08e2"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_snkb4")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_1yv7q"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
+serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 1], ["position", Vector2(421, 170)], ["block_formats", ["if    {cond: BOOL}", "else"]], ["statements", ["if {cond}:", "else:"]], ["param_input_strings_array", [{
+"cond": ""
+}, {}]]]
+
+[sub_resource type="Resource" id="Resource_mes51"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_1yv7q")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_pg8g3")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_1hfh0")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer1/SnapPoint"), SubResource("Resource_i08e2")]]
+
+[sub_resource type="Resource" id="Resource_n5h8k"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["param_input_strings", {
+"group": "Player"
+}]]
+
+[sub_resource type="Resource" id="Resource_jxuku"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_n5h8k")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mes51")]]
+
+[sub_resource type="Resource" id="Resource_sjnel"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
+serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(72, 63)]]
+
+[sub_resource type="Resource" id="Resource_qf1no"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_sjnel")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_jxuku")]]
+
+[sub_resource type="Resource" id="Resource_lw105"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
+"text": "Hi Will!"
+}]]
+
+[sub_resource type="Resource" id="Resource_n7lve"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_lw105")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_qvp1g"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "signal_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 2], ["position", Vector2(505, 254)], ["block_format", "On signal {signal: STRING}"], ["statement", ""], ["param_input_strings", {
+"signal": "will_hi"
+}]]
+
+[sub_resource type="Resource" id="Resource_e8kqc"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_qvp1g")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_n7lve")]]
+
+[sub_resource type="Resource" id="Resource_vnao2"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.290196, 0.52549, 0.835294, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add movement input with speed {speed: INT}"], ["statement", "velocity = Input.get_vector(\"Left\", \"Right\", \"Up\", \"Down\")*{speed}
@@ -115,136 +210,62 @@ move_and_slide()"], ["param_input_strings", {
 "speed": "500"
 }]]
 
-[sub_resource type="Resource" id="Resource_do4h8"]
+[sub_resource type="Resource" id="Resource_4lg3q"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_da88k")
+serialized_block = SubResource("Resource_vnao2")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_oaosl"]
+[sub_resource type="Resource" id="Resource_ok1n7"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "physics_process_block"], ["label", "On Physics Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(422, 99)]]
+serialized_props = [["block_name", "physics_process_block"], ["label", "On Physics Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(393, 105)]]
 
-[sub_resource type="Resource" id="Resource_gfq1s"]
+[sub_resource type="Resource" id="Resource_hx1o7"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_oaosl")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_do4h8")]]
+serialized_block = SubResource("Resource_ok1n7")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_4lg3q")]]
 
-[sub_resource type="Resource" id="Resource_ns4d2"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 6], ["position", Vector2(0, 0)], ["block_format", "Is in group {group: STRING}"], ["statement", "is_in_group({group})"], ["param_input_strings", {
-"group": "Enemy"
-}]]
-
-[sub_resource type="Resource" id="Resource_rs5i5"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_ns4d2")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_edc2l"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
-"text": "I am an enemy!"
-}]]
-
-[sub_resource type="Resource" id="Resource_32pf0"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_edc2l")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_kiv01"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
-"text": "I am not an enemy!"
-}]]
-
-[sub_resource type="Resource" id="Resource_4r02j"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_kiv01")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_hlm4o"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
-serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_formats", ["if    {cond: BOOL}", "else"]], ["statements", ["if {cond}:", "else:"]], ["param_input_strings_array", [{
-"cond": ""
-}, {}]]]
-
-[sub_resource type="Resource" id="Resource_ump54"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_hlm4o")
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_rs5i5")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_32pf0")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer1/SnapPoint"), SubResource("Resource_4r02j")]]
-
-[sub_resource type="Resource" id="Resource_0r1s4"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["param_input_strings", {
-"group": "Player"
-}]]
-
-[sub_resource type="Resource" id="Resource_rwiud"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_0r1s4")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ump54")]]
-
-[sub_resource type="Resource" id="Resource_rxnfq"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(72, 63)]]
-
-[sub_resource type="Resource" id="Resource_vj6il"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_rxnfq")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_rwiud")]]
-
-[sub_resource type="Resource" id="Resource_8060v"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
-"text": "Hi Will!"
-}]]
-
-[sub_resource type="Resource" id="Resource_nuaky"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_8060v")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_gl83f"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "signal_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 2], ["position", Vector2(515, 287)], ["block_format", "On signal {signal: STRING}"], ["statement", ""], ["param_input_strings", {
-"signal": "will_hi"
-}]]
-
-[sub_resource type="Resource" id="Resource_kmdth"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_gl83f")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_nuaky")]]
-
-[sub_resource type="Resource" id="Resource_o6eut"]
+[sub_resource type="Resource" id="Resource_2e420"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_0heby"]
+[sub_resource type="Resource" id="Resource_eeech"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_o6eut")
+serialized_block = SubResource("Resource_2e420")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_f55fl"]
+[sub_resource type="Resource" id="Resource_oxesf"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_5se7k"]
+[sub_resource type="Resource" id="Resource_62v5c"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_f55fl")
+serialized_block = SubResource("Resource_oxesf")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_kwirr"]
+[sub_resource type="Resource" id="Resource_eajwg"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_2x0uc"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_eajwg")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_8gnrd"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_l1b41"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_8gnrd")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_5xohf"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 6], ["position", Vector2(0, 0)], ["block_format", "Is {node: NODE} in group {group: STRING}"], ["statement", "{node}.is_in_group({group})"], ["param_input_strings", {
@@ -252,55 +273,55 @@ serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["col
 "node": ""
 }]]
 
-[sub_resource type="Resource" id="Resource_t6y8e"]
+[sub_resource type="Resource" id="Resource_3gamp"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_kwirr")
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_5se7k")]]
+serialized_block = SubResource("Resource_5xohf")
+path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_l1b41")]]
 
-[sub_resource type="Resource" id="Resource_ir0o2"]
+[sub_resource type="Resource" id="Resource_i6pun"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
 "text": "Ow."
 }]]
 
-[sub_resource type="Resource" id="Resource_bgjcg"]
+[sub_resource type="Resource" id="Resource_e6qla"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_ir0o2")
+serialized_block = SubResource("Resource_i6pun")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_q34xg"]
+[sub_resource type="Resource" id="Resource_88c47"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
 serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_formats", ["if    {cond: BOOL}"]], ["statements", ["if {cond}:"]], ["param_input_strings_array", [{
 "cond": ""
 }]]]
 
-[sub_resource type="Resource" id="Resource_i8n6p"]
+[sub_resource type="Resource" id="Resource_isyfp"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_q34xg")
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_t6y8e")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_bgjcg")]]
+serialized_block = SubResource("Resource_88c47")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_3gamp")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_e6qla")]]
 
-[sub_resource type="Resource" id="Resource_xl7v1"]
+[sub_resource type="Resource" id="Resource_yysqa"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 2], ["position", Vector2(383, 463)], ["block_format", "On body enter [body: NODE]"], ["statement", ""], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 2], ["position", Vector2(393, 446)], ["block_format", "On body enter [body: NODE]"], ["statement", ""], ["param_input_strings", {
 "body": ""
 }]]
 
-[sub_resource type="Resource" id="Resource_b7c4m"]
+[sub_resource type="Resource" id="Resource_5lphd"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_xl7v1")
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_0heby")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_i8n6p")]]
+serialized_block = SubResource("Resource_yysqa")
+path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_eeech")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_62v5c")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_2x0uc")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_isyfp")]]
 
-[sub_resource type="Resource" id="Resource_xgdt5"]
+[sub_resource type="Resource" id="Resource_lrt2n"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_gfq1s"), SubResource("Resource_vj6il"), SubResource("Resource_kmdth"), SubResource("Resource_b7c4m")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_qf1no"), SubResource("Resource_e8kqc"), SubResource("Resource_hx1o7"), SubResource("Resource_5lphd")])
 
 [sub_resource type="Resource" id="Resource_qakr4"]
 script = ExtResource("5_q37d3")
 script_inherits = "SimpleCharacter"
-block_trees = SubResource("Resource_xgdt5")
+block_trees = SubResource("Resource_lrt2n")
 generated_script = "extends SimpleCharacter
 
 var VAR_DICT := {}
@@ -324,6 +345,61 @@ func signal_will_hi():
 
 "
 
+[sub_resource type="Resource" id="Resource_5nem0"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set rotation degrees {angle: FLOAT}"], ["statement", "rotation = deg_to_rad({angle})"], ["param_input_strings", {
+"angle": "45"
+}]]
+
+[sub_resource type="Resource" id="Resource_dsu78"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_5nem0")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_xx1tt"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
+serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(147, 91)]]
+
+[sub_resource type="Resource" id="Resource_ys46d"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_xx1tt")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_dsu78")]]
+
+[sub_resource type="Resource" id="Resource_dde8v"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
+serialized_props = [["block_name", "process_block"], ["label", "On Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(468, 78)]]
+
+[sub_resource type="Resource" id="Resource_aelty"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_dde8v")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_hyyw1"]
+script = ExtResource("4_xt862")
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_ys46d"), SubResource("Resource_aelty")])
+
+[sub_resource type="Resource" id="Resource_iw7o0"]
+script = ExtResource("5_q37d3")
+script_inherits = "Node2D"
+block_trees = SubResource("Resource_hyyw1")
+generated_script = "extends Node2D
+
+var VAR_DICT := {}
+
+func _ready():
+	rotation = deg_to_rad(45)
+
+func _process(_delta):
+	pass
+
+func _physics_process(_delta):
+	pass
+
+"
+
 [node name="TestGame" type="Node2D"]
 
 [node name="Camera2D" type="Camera2D" parent="."]
@@ -341,3 +417,14 @@ position = Vector2(64, 6)
 [node name="BlockCode" type="Node" parent="Manuel"]
 script = ExtResource("2_ewral")
 bsd = SubResource("Resource_qakr4")
+
+[node name="Node2D" type="Node2D" parent="."]
+position = Vector2(-34, 39)
+scale = Vector2(0.25, 0.25)
+
+[node name="Sprite2D" type="Sprite2D" parent="Node2D"]
+texture = ExtResource("7_a27o8")
+
+[node name="BlockCode" type="Node" parent="Node2D"]
+script = ExtResource("2_ewral")
+bsd = SubResource("Resource_iw7o0")

--- a/test_game/test_game.tscn
+++ b/test_game/test_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=68 format=3 uid="uid://bbwmxee7ukgul"]
+[gd_scene load_steps=72 format=3 uid="uid://bbwmxee7ukgul"]
 
 [ext_resource type="PackedScene" uid="uid://ddx1cd5q6t61o" path="res://addons/block_code/simple_nodes/simple_character/simple_character.tscn" id="1_hrpwq"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="2_ewral"]
@@ -345,52 +345,78 @@ func signal_will_hi():
 
 "
 
-[sub_resource type="Resource" id="Resource_5nem0"]
+[sub_resource type="Resource" id="Resource_awu1c"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set rotation degrees {angle: FLOAT}"], ["statement", "rotation = deg_to_rad({angle})"], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Change Position by {value: VECTOR2}"], ["statement", "position += {value}"], ["param_input_strings", {
+"value": "100,10"
+}]]
+
+[sub_resource type="Resource" id="Resource_3alko"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_awu1c")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_bjnm4"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set Scale {value: VECTOR2}"], ["statement", "scale = {value}"], ["param_input_strings", {
+"value": "0.5,0.2"
+}]]
+
+[sub_resource type="Resource" id="Resource_xgj0d"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_bjnm4")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_3alko")]]
+
+[sub_resource type="Resource" id="Resource_vk6p1"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set Rotation Degrees {angle: FLOAT}"], ["statement", "rotation_degrees = {angle}"], ["param_input_strings", {
 "angle": "45"
 }]]
 
-[sub_resource type="Resource" id="Resource_dsu78"]
+[sub_resource type="Resource" id="Resource_mdc4c"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_5nem0")
-path_child_pairs = []
+serialized_block = SubResource("Resource_vk6p1")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_xgj0d")]]
 
-[sub_resource type="Resource" id="Resource_xx1tt"]
+[sub_resource type="Resource" id="Resource_kngk3"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
 serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(147, 91)]]
 
-[sub_resource type="Resource" id="Resource_ys46d"]
+[sub_resource type="Resource" id="Resource_shdae"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_xx1tt")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_dsu78")]]
+serialized_block = SubResource("Resource_kngk3")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mdc4c")]]
 
-[sub_resource type="Resource" id="Resource_dde8v"]
+[sub_resource type="Resource" id="Resource_ynybm"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
 serialized_props = [["block_name", "process_block"], ["label", "On Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(468, 78)]]
 
-[sub_resource type="Resource" id="Resource_aelty"]
+[sub_resource type="Resource" id="Resource_3sreo"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_dde8v")
+serialized_block = SubResource("Resource_ynybm")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_hyyw1"]
+[sub_resource type="Resource" id="Resource_14e2j"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_ys46d"), SubResource("Resource_aelty")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_shdae"), SubResource("Resource_3sreo")])
 
 [sub_resource type="Resource" id="Resource_iw7o0"]
 script = ExtResource("5_q37d3")
 script_inherits = "Node2D"
-block_trees = SubResource("Resource_hyyw1")
+block_trees = SubResource("Resource_14e2j")
 generated_script = "extends Node2D
 
 var VAR_DICT := {}
 
 func _ready():
-	rotation = deg_to_rad(45)
+	rotation_degrees = 45
+	scale = Vector2(0.5,0.2)
+	position += Vector2(100,10)
 
 func _process(_delta):
 	pass


### PR DESCRIPTION
This adds a way to add custom blocks to a specific built-in class. You can either expose a property (given it's `Variant.Type` can match a `Types.BlockType`), or create a custom block for more control. See `get_built_in_categories()` in `CategoryFactory`.

You can find an example of this for `Node2D` in test scene.

Something to think about at some point is how we can define our types better. Should we have a `NUMBER` type that allows for integer and float input? And do we need a way to have type inheritance, such that we could keep the `INT` and `FLOAT` types, but they are still a `NUMBER`? I think defining our own types is a fine thing to do, as we want to add a layer of abstraction.

I also made the styling a bit nicer, LMK if you don't like it. Essentially just gave the blocks a bit more margin space and gave outlines to parameter blocks.