### PR TITLE
Add EntryBlock class

### DIFF
--- a/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
@@ -9,24 +9,14 @@ func generate_script_from_current_window(script_inherits: String = ""):
 
 	var blocks := current_window.get_children()
 
-	var ready_nodes: Array[BasicBlock] = []
-	var process_nodes: Array[BasicBlock] = []
-	var physics_process_nodes: Array[BasicBlock] = []
-	var signal_nodes: Array[StatementBlock] = []
+	var entry_blocks: Array[EntryBlock] = []
 
 	for c in blocks:
 		if !(c is Block):
 			continue
 
-		match c.block_name:
-			"ready_block":
-				ready_nodes.append(c)
-			"process_block":
-				process_nodes.append(c)
-			"physics_process_block":
-				physics_process_nodes.append(c)
-			"signal_block":
-				signal_nodes.append(c)
+		if c is EntryBlock:
+			entry_blocks.append(c)
 
 	var script: String = ""
 
@@ -34,40 +24,19 @@ func generate_script_from_current_window(script_inherits: String = ""):
 
 	script += "var VAR_DICT := {}\n\n"
 
-	var node_groups = [["func _ready():", ready_nodes], ["func _process(_delta):", process_nodes], ["func _physics_process(_delta):", physics_process_nodes]]
+	for entry_block in entry_blocks:
+		script += entry_block.get_entry_statement() + "\n"
 
-	# Get signal entries
-	var signal_groups: Dictionary = {}
-	for signal_node in signal_nodes:
-		# Little bit hacky to get first param
-		var signal_name: String = signal_node.param_name_input_pairs[0][1].get_plain_text()
-		if signal_groups.has(signal_name):
-			signal_groups[signal_name].append(signal_node)
-		else:
-			signal_groups[signal_name] = [signal_node]
+		var next_block := entry_block.bottom_snap.get_snapped_block()
 
-	for signal_name in signal_groups:
-		node_groups.append(["func signal_%s():" % signal_name, signal_groups[signal_name]])
-
-	for section in node_groups:
-		script += section[0] + "\n"
-
-		var should_pass: bool = true
-		for block in section[1]:
-			if block.bottom_snap.get_snapped_block():
-				should_pass = false
-				break
-
-		if should_pass:
+		if next_block == null:
 			script += "\tpass\n"
 		else:
-			for block in section[1]:
-				var generator: InstructionTree = InstructionTree.new()
-				var instruction_node: InstructionTree.TreeNode = block.get_instruction_node()
-				var to_append := generator.generate_text(instruction_node, 1)
-				script += to_append
+			var generator: InstructionTree = InstructionTree.new()
+			var instruction_node: InstructionTree.TreeNode = next_block.get_instruction_node()
+			var to_append := generator.generate_text(instruction_node, 1)
+			script += to_append
 
-		#script += "\n\tsuper()\n\n"
 		script += "\n"
 
 	return script

--- a/addons/block_code/ui/blocks/entry_block/entry_block.gd
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.gd
@@ -1,0 +1,24 @@
+@tool
+class_name EntryBlock
+extends StatementBlock
+
+
+func _ready():
+	super()
+
+
+func get_scene_path():
+	return "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+
+
+func get_entry_statement() -> String:
+	var formatted_statement := statement
+
+	for pair in param_name_input_pairs:
+		formatted_statement = formatted_statement.replace("{%s}" % pair[0], pair[1].get_string())
+
+	# One line, should not have \n
+	if formatted_statement.find("\n") != -1:
+		push_error("Entry block has multiline statement.")
+
+	return formatted_statement

--- a/addons/block_code/ui/blocks/entry_block/entry_block.tscn
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://d2fibflv3ojys"]
+
+[ext_resource type="PackedScene" uid="uid://c84vmg3odrtxt" path="res://addons/block_code/ui/blocks/statement_block/statement_block.tscn" id="1_byjbb"]
+[ext_resource type="Script" path="res://addons/block_code/ui/blocks/entry_block/entry_block.gd" id="2_3ik8h"]
+
+[node name="EntryBlock" instance=ExtResource("1_byjbb")]
+script = ExtResource("2_3ik8h")
+block_name = "entry_block"
+label = "EntryBlock"
+block_type = 2

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vvwx0"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0afbg"]
 bg_color = Color(1, 1, 1, 1)
 border_width_left = 3
 border_width_top = 3
@@ -26,7 +26,7 @@ block_type = 3
 [node name="Panel" type="Panel" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_vvwx0")
+theme_override_styles/panel = SubResource("StyleBoxFlat_0afbg")
 
 [node name="DragDropArea" parent="." instance=ExtResource("2_gy5co")]
 layout_mode = 2

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -6,6 +6,7 @@ const BLOCKS: Dictionary = {
 	"control_block": preload("res://addons/block_code/ui/blocks/control_block/control_block.tscn"),
 	"parameter_block": preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"),
 	"statement_block": preload("res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"),
+	"entry_block": preload("res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"),
 }
 
 
@@ -14,22 +15,22 @@ static func get_general_categories() -> Array[BlockCategory]:
 
 	# Entry
 	var entry_list: Array[Block] = []
-	b = BLOCKS["basic_block"].instantiate()
+	b = BLOCKS["entry_block"].instantiate()
 	b.block_name = "ready_block"
-	b.label = "On Ready"
-	b.block_type = Types.BlockType.ENTRY
+	b.block_format = "On Ready"
+	b.statement = "func _ready():"
 	entry_list.append(b)
 
-	b = BLOCKS["basic_block"].instantiate()
+	b = BLOCKS["entry_block"].instantiate()
 	b.block_name = "process_block"
-	b.label = "On Process"
-	b.block_type = Types.BlockType.ENTRY
+	b.block_format = "On Process"
+	b.statement = "func _process(delta):"
 	entry_list.append(b)
 
-	b = BLOCKS["basic_block"].instantiate()
+	b = BLOCKS["entry_block"].instantiate()
 	b.block_name = "physics_process_block"
-	b.label = "On Physics Process"
-	b.block_type = Types.BlockType.ENTRY
+	b.block_format = "On Physics Process"
+	b.statement = "func _physics_process(delta):"
 	entry_list.append(b)
 
 	var entry_cat: BlockCategory = BlockCategory.new("Entry", entry_list, Color("fa5956"))
@@ -64,9 +65,9 @@ static func get_general_categories() -> Array[BlockCategory]:
 	b.statement = "print({text})"
 	test_list.append(b)
 
-	b = BLOCKS["statement_block"].instantiate()
-	b.block_type = Types.BlockType.ENTRY
+	b = BLOCKS["entry_block"].instantiate()
 	b.block_format = "On body enter [body: NODE]"
+	b.statement = "func _on_body_enter(body):"
 	test_list.append(b)
 
 	var test_cat: BlockCategory = BlockCategory.new("Test", test_list, Color("9989df"))
@@ -74,10 +75,11 @@ static func get_general_categories() -> Array[BlockCategory]:
 	# Signal
 	var signal_list: Array[Block] = []
 
-	b = BLOCKS["statement_block"].instantiate()
-	b.block_name = "signal_block"
-	b.block_type = Types.BlockType.ENTRY
-	b.block_format = "On signal {signal: STRING}"
+	b = BLOCKS["entry_block"].instantiate()
+	# HACK: make signals work with new entry nodes. NONE instead of STRING type allows
+	# plain text input for function name. Should revamp signals later
+	b.block_format = "On signal {signal: NONE}"
+	b.statement = "func signal_{signal}():"
 	signal_list.append(b)
 
 	b = BLOCKS["statement_block"].instantiate()

--- a/test_game/test_game.tscn
+++ b/test_game/test_game.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Script" path="res://addons/block_code/block_script_data/block_script_data.gd" id="5_q37d3"]
 [ext_resource type="Texture2D" uid="uid://dr8e0tvfxjy1f" path="res://icon.svg" id="7_a27o8"]
 
-[sub_resource type="Resource" id="Resource_2813a"]
+[sub_resource type="Resource" id="Resource_nkm54"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.290196, 0.52549, 0.835294, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Move with player 2 buttons, speed {speed: INT}"], ["statement", "velocity = Input.get_vector(\"player_2_left\", \"player_2_right\", \"player_2_up\", \"player_2_down\")*{speed}
@@ -16,22 +16,22 @@ move_and_slide()"], ["param_input_strings", {
 "speed": "600"
 }]]
 
-[sub_resource type="Resource" id="Resource_72uqc"]
+[sub_resource type="Resource" id="Resource_y5ca8"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_2813a")
+serialized_block = SubResource("Resource_nkm54")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_0kvba"]
+[sub_resource type="Resource" id="Resource_wwvqu"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "physics_process_block"], ["label", "On Physics Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(426, 55)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "physics_process_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(460, 94)], ["block_format", "On Physics Process"], ["statement", "func _physics_process(delta):"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_vaqs6"]
+[sub_resource type="Resource" id="Resource_8or12"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_0kvba")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_72uqc")]]
+serialized_block = SubResource("Resource_wwvqu")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_y5ca8")]]
 
-[sub_resource type="Resource" id="Resource_u4kq5"]
+[sub_resource type="Resource" id="Resource_q0sd7"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Send signal {signal: STRING} to group {group: STRING}"], ["statement", "var signal_manager = get_tree().root.get_node_or_null(\"SignalManager\")
@@ -41,56 +41,60 @@ if signal_manager:
 "signal": "will_hi"
 }]]
 
-[sub_resource type="Resource" id="Resource_bx1dl"]
+[sub_resource type="Resource" id="Resource_jd4ea"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_u4kq5")
+serialized_block = SubResource("Resource_q0sd7")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_5fufs"]
+[sub_resource type="Resource" id="Resource_04kfr"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["param_input_strings", {
 "group": "Player"
 }]]
 
-[sub_resource type="Resource" id="Resource_63xmq"]
+[sub_resource type="Resource" id="Resource_8th8a"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_5fufs")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_bx1dl")]]
+serialized_block = SubResource("Resource_04kfr")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_jd4ea")]]
 
-[sub_resource type="Resource" id="Resource_qyij3"]
+[sub_resource type="Resource" id="Resource_bv450"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
 "text": "Hi Manuel!"
 }]]
 
-[sub_resource type="Resource" id="Resource_hlja5"]
+[sub_resource type="Resource" id="Resource_cg08g"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_qyij3")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_63xmq")]]
+serialized_block = SubResource("Resource_bv450")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_8th8a")]]
 
-[sub_resource type="Resource" id="Resource_uq4pm"]
+[sub_resource type="Resource" id="Resource_f81dv"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(43, 113)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(104, 85)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_vep2i"]
+[sub_resource type="Resource" id="Resource_m28mx"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_uq4pm")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_hlja5")]]
+serialized_block = SubResource("Resource_f81dv")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_cg08g")]]
 
-[sub_resource type="Resource" id="Resource_5242x"]
+[sub_resource type="Resource" id="Resource_xlqhk"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_vaqs6"), SubResource("Resource_vep2i")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_8or12"), SubResource("Resource_m28mx")])
 
 [sub_resource type="Resource" id="Resource_l007i"]
 script = ExtResource("5_q37d3")
 script_inherits = "SimpleCharacter"
-block_trees = SubResource("Resource_5242x")
+block_trees = SubResource("Resource_xlqhk")
 generated_script = "extends SimpleCharacter
 
 var VAR_DICT := {}
+
+func _physics_process(delta):
+	velocity = Input.get_vector(\"player_2_left\", \"player_2_right\", \"player_2_up\", \"player_2_down\")*600
+	move_and_slide()
 
 func _ready():
 	print('Hi Manuel!')
@@ -99,110 +103,79 @@ func _ready():
 	if signal_manager:
 		signal_manager.broadcast_signal('Player', 'will_hi')
 
-func _process(_delta):
-	pass
-
-func _physics_process(_delta):
-	velocity = Input.get_vector(\"player_2_left\", \"player_2_right\", \"player_2_up\", \"player_2_down\")*600
-	move_and_slide()
-
 "
 
-[sub_resource type="Resource" id="Resource_rwe0r"]
+[sub_resource type="Resource" id="Resource_1csgb"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 6], ["position", Vector2(0, 0)], ["block_format", "Is in group {group: STRING}"], ["statement", "is_in_group({group})"], ["param_input_strings", {
 "group": "Enemy"
 }]]
 
-[sub_resource type="Resource" id="Resource_m05n7"]
+[sub_resource type="Resource" id="Resource_4duoa"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_rwe0r")
+serialized_block = SubResource("Resource_1csgb")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_bq3di"]
+[sub_resource type="Resource" id="Resource_cuaa7"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
 "text": "I am an enemy!"
 }]]
 
-[sub_resource type="Resource" id="Resource_p1nfx"]
+[sub_resource type="Resource" id="Resource_q1djl"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_bq3di")
+serialized_block = SubResource("Resource_cuaa7")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_cmkht"]
+[sub_resource type="Resource" id="Resource_x2hw0"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
 "text": "I am not an enemy!"
 }]]
 
-[sub_resource type="Resource" id="Resource_001bo"]
+[sub_resource type="Resource" id="Resource_q55lx"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_cmkht")
+serialized_block = SubResource("Resource_x2hw0")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_4w6n7"]
+[sub_resource type="Resource" id="Resource_qy43j"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
 serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_formats", ["if    {cond: BOOL}", "else"]], ["statements", ["if {cond}:", "else:"]], ["param_input_strings_array", [{
 "cond": ""
 }, {}]]]
 
-[sub_resource type="Resource" id="Resource_wp2fi"]
+[sub_resource type="Resource" id="Resource_gaj4r"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_4w6n7")
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_m05n7")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_p1nfx")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer1/SnapPoint"), SubResource("Resource_001bo")]]
+serialized_block = SubResource("Resource_qy43j")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_4duoa")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_q1djl")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer1/SnapPoint"), SubResource("Resource_q55lx")]]
 
-[sub_resource type="Resource" id="Resource_djpfi"]
+[sub_resource type="Resource" id="Resource_a66i4"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["param_input_strings", {
 "group": "Player"
 }]]
 
-[sub_resource type="Resource" id="Resource_ighiv"]
+[sub_resource type="Resource" id="Resource_ofpli"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_djpfi")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_wp2fi")]]
+serialized_block = SubResource("Resource_a66i4")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_gaj4r")]]
 
-[sub_resource type="Resource" id="Resource_u2g7c"]
+[sub_resource type="Resource" id="Resource_hujyr"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(72, 63)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(105, 34)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_vxrrh"]
+[sub_resource type="Resource" id="Resource_gvdts"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_u2g7c")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ighiv")]]
+serialized_block = SubResource("Resource_hujyr")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ofpli")]]
 
-[sub_resource type="Resource" id="Resource_h4nti"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
-"text": "Hi Will!"
-}]]
-
-[sub_resource type="Resource" id="Resource_xir6w"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_h4nti")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_bjpkx"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "signal_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 2], ["position", Vector2(505, 254)], ["block_format", "On signal {signal: STRING}"], ["statement", ""], ["param_input_strings", {
-"signal": "will_hi"
-}]]
-
-[sub_resource type="Resource" id="Resource_jsgn8"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_bjpkx")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_xir6w")]]
-
-[sub_resource type="Resource" id="Resource_rjd7u"]
+[sub_resource type="Resource" id="Resource_70nnj"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.290196, 0.52549, 0.835294, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Move with player 1 buttons, speed {speed: INT}"], ["statement", "velocity = Input.get_vector(\"ui_left\", \"ui_right\", \"ui_up\", \"ui_down\")*{speed}
@@ -210,82 +183,62 @@ move_and_slide()"], ["param_input_strings", {
 "speed": "200"
 }]]
 
-[sub_resource type="Resource" id="Resource_vtw0a"]
+[sub_resource type="Resource" id="Resource_u0o8t"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_rjd7u")
+serialized_block = SubResource("Resource_70nnj")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_bi0ay"]
+[sub_resource type="Resource" id="Resource_11s1f"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "physics_process_block"], ["label", "On Physics Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(393, 105)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "physics_process_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(437, 62)], ["block_format", "On Physics Process"], ["statement", "func _physics_process(delta):"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_hydb1"]
+[sub_resource type="Resource" id="Resource_7nep4"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_bi0ay")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_vtw0a")]]
+serialized_block = SubResource("Resource_11s1f")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_u0o8t")]]
 
-[sub_resource type="Resource" id="Resource_ro4nt"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 8], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_aaler"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_ro4nt")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_mm5wq"]
+[sub_resource type="Resource" id="Resource_i102m"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 8], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_0ps3d"]
+[sub_resource type="Resource" id="Resource_3k10n"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_mm5wq")
+serialized_block = SubResource("Resource_i102m")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_egfse"]
+[sub_resource type="Resource" id="Resource_8mpct"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 8], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_l0uoa"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_8mpct")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_e188f"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 8], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_tbxx4"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_e188f")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_ioreq"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_g5dtv"]
+[sub_resource type="Resource" id="Resource_7e0oe"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_egfse")
+serialized_block = SubResource("Resource_ioreq")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_1tujm"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_jiya7"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_1tujm")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_ilabs"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_dw460"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_ilabs")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_msu7k"]
-script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 7], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["param_input_strings", {}]]
-
-[sub_resource type="Resource" id="Resource_fgjn0"]
-script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_msu7k")
-path_child_pairs = []
-
-[sub_resource type="Resource" id="Resource_aeuj8"]
+[sub_resource type="Resource" id="Resource_7f05b"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
 serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 6], ["position", Vector2(0, 0)], ["block_format", "Is {node: NODE} in group {group: STRING}"], ["statement", "{node}.is_in_group({group})"], ["param_input_strings", {
@@ -293,55 +246,79 @@ serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["col
 "node": ""
 }]]
 
-[sub_resource type="Resource" id="Resource_f4jiv"]
+[sub_resource type="Resource" id="Resource_723lt"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_aeuj8")
-path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_fgjn0")]]
+serialized_block = SubResource("Resource_7f05b")
+path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_7e0oe")]]
 
-[sub_resource type="Resource" id="Resource_3h57o"]
+[sub_resource type="Resource" id="Resource_gegsu"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
 "text": "Ow."
 }]]
 
-[sub_resource type="Resource" id="Resource_dw0xv"]
+[sub_resource type="Resource" id="Resource_ehk0q"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_3h57o")
+serialized_block = SubResource("Resource_gegsu")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_0i643"]
+[sub_resource type="Resource" id="Resource_cta2p"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
 serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_formats", ["if    {cond: BOOL}"]], ["statements", ["if {cond}:"]], ["param_input_strings_array", [{
 "cond": ""
 }]]]
 
-[sub_resource type="Resource" id="Resource_t67gm"]
+[sub_resource type="Resource" id="Resource_ww4ph"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_0i643")
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_f4jiv")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_dw0xv")]]
+serialized_block = SubResource("Resource_cta2p")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_723lt")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_ehk0q")]]
 
-[sub_resource type="Resource" id="Resource_pdbcq"]
+[sub_resource type="Resource" id="Resource_um7l6"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 2], ["position", Vector2(393, 446)], ["block_format", "On body enter [body: NODE]"], ["statement", ""], ["param_input_strings", {
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "entry_block"], ["label", "EntryBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 2], ["position", Vector2(472, 469)], ["block_format", "On body enter [body: NODE]"], ["statement", "func _on_body_enter(body):"], ["param_input_strings", {
 "body": ""
 }]]
 
-[sub_resource type="Resource" id="Resource_327u1"]
+[sub_resource type="Resource" id="Resource_c7qnw"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_pdbcq")
-path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_aaler")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_0ps3d")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_g5dtv")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_jiya7")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_dw460")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_t67gm")]]
+serialized_block = SubResource("Resource_um7l6")
+path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_3k10n")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_l0uoa")], [NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_tbxx4")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ww4ph")]]
 
-[sub_resource type="Resource" id="Resource_8ogvx"]
+[sub_resource type="Resource" id="Resource_q6axr"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
+"text": "Hi Will!"
+}]]
+
+[sub_resource type="Resource" id="Resource_qsqhp"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_q6axr")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_g4l32"]
+script = ExtResource("3_dpt5n")
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "entry_block"], ["label", "EntryBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 2], ["position", Vector2(537, 268)], ["block_format", "On signal {signal: NONE}"], ["statement", "func signal_{signal}():"], ["param_input_strings", {
+"signal": "will_hi"
+}]]
+
+[sub_resource type="Resource" id="Resource_iag1u"]
+script = ExtResource("2_pqvcj")
+serialized_block = SubResource("Resource_g4l32")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_qsqhp")]]
+
+[sub_resource type="Resource" id="Resource_gera1"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_vxrrh"), SubResource("Resource_jsgn8"), SubResource("Resource_hydb1"), SubResource("Resource_327u1")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_gvdts"), SubResource("Resource_7nep4"), SubResource("Resource_c7qnw"), SubResource("Resource_iag1u")])
 
 [sub_resource type="Resource" id="Resource_qakr4"]
 script = ExtResource("5_q37d3")
 script_inherits = "SimpleCharacter"
-block_trees = SubResource("Resource_8ogvx")
+block_trees = SubResource("Resource_gera1")
 generated_script = "extends SimpleCharacter
 
 var VAR_DICT := {}
@@ -353,82 +330,83 @@ func _ready():
 	else:
 		print('I am not an enemy!')
 
-func _process(_delta):
-	pass
-
-func _physics_process(_delta):
+func _physics_process(delta):
 	velocity = Input.get_vector(\"ui_left\", \"ui_right\", \"ui_up\", \"ui_down\")*200
 	move_and_slide()
+
+func _on_body_enter(body):
+	if body.is_in_group('Enemy'):
+		print('Ow.')
 
 func signal_will_hi():
 	print('Hi Will!')
 
 "
 
-[sub_resource type="Resource" id="Resource_awu1c"]
+[sub_resource type="Resource" id="Resource_hoesv"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Change Position by {value: VECTOR2}"], ["statement", "position += {value}"], ["param_input_strings", {
 "value": "100,10"
 }]]
 
-[sub_resource type="Resource" id="Resource_3alko"]
+[sub_resource type="Resource" id="Resource_70fia"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_awu1c")
+serialized_block = SubResource("Resource_hoesv")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_bjnm4"]
+[sub_resource type="Resource" id="Resource_s5o77"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set Scale {value: VECTOR2}"], ["statement", "scale = {value}"], ["param_input_strings", {
 "value": "0.5,0.2"
 }]]
 
-[sub_resource type="Resource" id="Resource_xgj0d"]
+[sub_resource type="Resource" id="Resource_idqtv"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_bjnm4")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_3alko")]]
+serialized_block = SubResource("Resource_s5o77")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_70fia")]]
 
-[sub_resource type="Resource" id="Resource_vk6p1"]
+[sub_resource type="Resource" id="Resource_5s6w6"]
 script = ExtResource("3_dpt5n")
 block_path = "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Set Rotation Degrees {angle: FLOAT}"], ["statement", "rotation_degrees = {angle}"], ["param_input_strings", {
 "angle": "45"
 }]]
 
-[sub_resource type="Resource" id="Resource_mdc4c"]
+[sub_resource type="Resource" id="Resource_xtjhk"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_vk6p1")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_xgj0d")]]
+serialized_block = SubResource("Resource_5s6w6")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_idqtv")]]
 
-[sub_resource type="Resource" id="Resource_kngk3"]
+[sub_resource type="Resource" id="Resource_1kmqq"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "ready_block"], ["label", "On Ready"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(147, 91)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(186, 175)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_shdae"]
+[sub_resource type="Resource" id="Resource_i3ojy"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_kngk3")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mdc4c")]]
+serialized_block = SubResource("Resource_1kmqq")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_xtjhk")]]
 
-[sub_resource type="Resource" id="Resource_ynybm"]
+[sub_resource type="Resource" id="Resource_17vhp"]
 script = ExtResource("3_dpt5n")
-block_path = "res://addons/block_code/ui/blocks/basic_block/basic_block.tscn"
-serialized_props = [["block_name", "process_block"], ["label", "On Process"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(468, 78)]]
+block_path = "res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"
+serialized_props = [["block_name", "process_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 2], ["position", Vector2(571, 99)], ["block_format", "On Process"], ["statement", "func _process(delta):"], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_3sreo"]
+[sub_resource type="Resource" id="Resource_g7ibk"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_ynybm")
+serialized_block = SubResource("Resource_17vhp")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_14e2j"]
+[sub_resource type="Resource" id="Resource_l8ktp"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_shdae"), SubResource("Resource_3sreo")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_i3ojy"), SubResource("Resource_g7ibk")])
 
 [sub_resource type="Resource" id="Resource_iw7o0"]
 script = ExtResource("5_q37d3")
 script_inherits = "Node2D"
-block_trees = SubResource("Resource_14e2j")
+block_trees = SubResource("Resource_l8ktp")
 generated_script = "extends Node2D
 
 var VAR_DICT := {}
@@ -438,10 +416,7 @@ func _ready():
 	scale = Vector2(0.5,0.2)
 	position += Vector2(100,10)
 
-func _process(_delta):
-	pass
-
-func _physics_process(_delta):
+func _process(delta):
 	pass
 
 "


### PR DESCRIPTION
This felt like a good addition to have, since before the script generator was looking for a `block_name` for entry blocks, and generating the code itself, but now it asks the `EntryBlock` for the code, and appends it to the script that way.

`EntryBlock` inherits from `StatementBlock` (both scene and script), utilizing the statement block to generate the parameters UI programatically. This way we can expose things like signals by automatically creating an `EntryBlock` for them.

Originally we had been using `BasicBlock` as a template for entry blocks, but it is much nicer to have an `EntryBlock` that can actually generate a method signature.