### PR TITLE
instruction_tree: Remove unused generate_tree() method

### DIFF
--- a/addons/block_code/instruction_tree/instruction_tree.gd
+++ b/addons/block_code/instruction_tree/instruction_tree.gd
@@ -17,10 +17,6 @@ class TreeNode:
 		children.append(node)
 
 
-func generate_tree(root_block: Block) -> TreeNode:
-	return root_block.get_instruction()
-
-
 func generate_text(root_node: TreeNode, start_depth: int = 0) -> String:
 	out = ""
 	depth = start_depth


### PR DESCRIPTION
This method was introduced in 0b392c281a31d7f41031674debe7cc06e949fff5 but never used.