### PR TITLE
instruction_tree: Pass depth & output buffer as parameters

### DIFF
--- a/addons/block_code/instruction_tree/instruction_tree.gd
+++ b/addons/block_code/instruction_tree/instruction_tree.gd
@@ -1,8 +1,6 @@
 class_name InstructionTree
 extends Object
 
-var out: String
-
 
 class TreeNode:
 	var data: String
@@ -17,19 +15,17 @@ class TreeNode:
 
 
 func generate_text(root_node: TreeNode, start_depth: int = 0) -> String:
-	out = ""
-	generate_text_recursive(root_node, start_depth)
-	return out
+	var out = PackedStringArray()
+	generate_text_recursive(root_node, start_depth, out)
+	return "".join(out)
 
 
-func generate_text_recursive(node: TreeNode, depth: int):
+func generate_text_recursive(node: TreeNode, depth: int, out: PackedStringArray):
 	if node.data != "":
-		for i in depth:
-			out += "\t"
-		out += node.data + "\n"
+		out.append("\t".repeat(depth) + node.data + "\n")
 
 	for c in node.children:
-		generate_text_recursive(c, depth + 1)
+		generate_text_recursive(c, depth + 1, out)
 
 	if node.next:
-		generate_text_recursive(node.next, depth)
+		generate_text_recursive(node.next, depth, out)

--- a/addons/block_code/instruction_tree/instruction_tree.gd
+++ b/addons/block_code/instruction_tree/instruction_tree.gd
@@ -24,18 +24,18 @@ func generate_text(root_node: TreeNode, start_depth: int = 0) -> String:
 	return out
 
 
-func generate_text_recursive(root_node: TreeNode):
-	if root_node.data != "":
+func generate_text_recursive(node: TreeNode):
+	if node.data != "":
 		for i in depth:
 			out += "\t"
-		out += root_node.data + "\n"
+		out += node.data + "\n"
 
 	depth += 1
 
-	for c in root_node.children:
+	for c in node.children:
 		generate_text_recursive(c)
 
 	depth -= 1
 
-	if root_node.next:
-		generate_text_recursive(root_node.next)
+	if node.next:
+		generate_text_recursive(node.next)

--- a/addons/block_code/instruction_tree/instruction_tree.gd
+++ b/addons/block_code/instruction_tree/instruction_tree.gd
@@ -1,7 +1,6 @@
 class_name InstructionTree
 extends Object
 
-var depth: int
 var out: String
 
 
@@ -19,23 +18,18 @@ class TreeNode:
 
 func generate_text(root_node: TreeNode, start_depth: int = 0) -> String:
 	out = ""
-	depth = start_depth
-	generate_text_recursive(root_node)
+	generate_text_recursive(root_node, start_depth)
 	return out
 
 
-func generate_text_recursive(node: TreeNode):
+func generate_text_recursive(node: TreeNode, depth: int):
 	if node.data != "":
 		for i in depth:
 			out += "\t"
 		out += node.data + "\n"
 
-	depth += 1
-
 	for c in node.children:
-		generate_text_recursive(c)
-
-	depth -= 1
+		generate_text_recursive(c, depth + 1)
 
 	if node.next:
-		generate_text_recursive(node.next)
+		generate_text_recursive(node.next, depth)


### PR DESCRIPTION
I think this is clearer than using instance variables, which persist beyond the call to generate_text, to store state which is transient to any given call to generate_text. It's also shorter!