### PR TITLE
Pong demo: Fix ball velocity decay

### DIFF
--- a/pong_game/ball.tscn
+++ b/pong_game/ball.tscn
@@ -20,6 +20,8 @@ continuous_cd = 1
 max_contacts_reported = 1
 contact_monitor = true
 linear_velocity = Vector2(353.553, 353.553)
+linear_damp_mode = 1
+angular_damp_mode = 1
 script = ExtResource("1_vdrab")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]


### PR DESCRIPTION
In moddable pong the project had linear damp and angular damp in zero. To do that only for the ball (not project wide) we can set linear and angular damp mode to "replace" in the RigidBody2D.

https://phabricator.endlessm.com/T35504