### PR TITLE
BlockCode node: Rename bsd to block_script

### DIFF
--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -3,7 +3,7 @@
 class_name BlockCode
 extends Node
 
-@export var bsd: BlockScriptData = null
+@export var block_script: BlockScriptData = null
 static var plugin
 
 
@@ -25,11 +25,11 @@ func _enter_tree():
 		return
 
 	# Create script
-	if bsd == null:
+	if block_script == null:
 		var new_bsd: BlockScriptData = load("res://addons/block_code/ui/bsd_templates/default_bsd.tres").duplicate(true)
 		new_bsd.script_inherits = _get_custom_or_native_class(get_parent())
 		new_bsd.generated_script = new_bsd.generated_script.replace("INHERIT_DEFAULT", new_bsd.script_inherits)
-		bsd = new_bsd
+		block_script = new_bsd
 
 	if plugin == null:
 		plugin = ClassDB.instantiate("EditorPlugin")
@@ -43,7 +43,7 @@ func _update_parent_script():
 
 	var parent: Node = get_parent()
 	var script := GDScript.new()
-	script.set_source_code(bsd.generated_script)
+	script.set_source_code(block_script.generated_script)
 	script.reload()
 	parent.set_script(script)
 	parent.set_process(true)
@@ -51,7 +51,7 @@ func _update_parent_script():
 
 func _get_configuration_warnings():
 	var warnings = []
-	if bsd and _get_custom_or_native_class(get_parent()) != bsd.script_inherits:
-		var warning = "The parent is not a %s. Create a new BlockCode node and reattach." % bsd.script_inherits
+	if block_script and _get_custom_or_native_class(get_parent()) != block_script.script_inherits:
+		var warning = "The parent is not a %s. Create a new BlockCode node and reattach." % block_script.script_inherits
 		warnings.append(warning)
 	return warnings

--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -40,7 +40,7 @@ func switch_scene(scene_root: Node):
 
 
 func switch_script(block_code_node: BlockCode):
-	var bsd = block_code_node.bsd if block_code_node else null
+	var bsd = block_code_node.block_script if block_code_node else null
 	_current_bsd = bsd
 	_current_block_code_node = block_code_node
 	_picker.bsd_selected(bsd)

--- a/addons/block_code/ui/title_bar/title_bar.gd
+++ b/addons/block_code/ui/title_bar/title_bar.gd
@@ -44,7 +44,7 @@ func _update_node_option_button_options():
 
 	for block_code_node in scene_root.find_children("*", "BlockCode"):
 		var node_item_index = _node_option_button.item_count
-		var node_label = "{name} ({type})".format({"name": scene_root.get_path_to(block_code_node).get_concatenated_names(), "type": block_code_node.bsd.script_inherits})
+		var node_label = "{name} ({type})".format({"name": scene_root.get_path_to(block_code_node).get_concatenated_names(), "type": block_code_node.block_script.script_inherits})
 		_node_option_button.add_item(node_label)
 		_node_option_button.set_item_icon(node_item_index, _block_code_icon)
 		_node_option_button.set_item_metadata(node_item_index, block_code_node)
@@ -53,7 +53,7 @@ func _update_node_option_button_options():
 func _get_index_for_bsd(bsd: BlockScriptData) -> int:
 	for index in range(_node_option_button.item_count):
 		var block_code_node = _node_option_button.get_item_metadata(index)
-		if block_code_node.bsd == bsd:
+		if block_code_node.block_script == bsd:
 			return index
 	return -1
 

--- a/pong_game/pong_game.tscn
+++ b/pong_game/pong_game.tscn
@@ -158,7 +158,7 @@ position = Vector2(64, 544)
 
 [node name="BlockCode" type="Node" parent="PaddleLeft"]
 script = ExtResource("3_6jaq8")
-bsd = SubResource("Resource_t7nl4")
+block_script = SubResource("Resource_t7nl4")
 
 [node name="PaddleRight" parent="." instance=ExtResource("1_1k5k2")]
 modulate = Color(0.511, 0.362, 0.972, 1)
@@ -166,7 +166,7 @@ position = Vector2(1856, 544)
 
 [node name="BlockCode" type="Node" parent="PaddleRight"]
 script = ExtResource("3_6jaq8")
-bsd = SubResource("Resource_52r02")
+block_script = SubResource("Resource_52r02")
 
 [node name="Ball" parent="." instance=ExtResource("9_xrqll")]
 modulate = Color(0.511, 0.362, 0.972, 1)
@@ -186,4 +186,4 @@ position = Vector2(1984, 544)
 
 [node name="BlockCode" type="Node" parent="."]
 script = ExtResource("3_6jaq8")
-bsd = SubResource("Resource_f070g")
+block_script = SubResource("Resource_f070g")

--- a/test_game/test_game.tscn
+++ b/test_game/test_game.tscn
@@ -1114,14 +1114,14 @@ position = Vector2(-71, -18)
 
 [node name="BlockCode" type="Node" parent="Will"]
 script = ExtResource("2_ewral")
-bsd = SubResource("Resource_l007i")
+block_script = SubResource("Resource_l007i")
 
 [node name="Manuel" parent="." instance=ExtResource("1_hrpwq")]
 position = Vector2(64, 6)
 
 [node name="BlockCode" type="Node" parent="Manuel"]
 script = ExtResource("2_ewral")
-bsd = SubResource("Resource_qakr4")
+block_script = SubResource("Resource_qakr4")
 
 [node name="Node2D" type="Node2D" parent="."]
 position = Vector2(-34, 39)
@@ -1132,7 +1132,7 @@ texture = ExtResource("7_a27o8")
 
 [node name="BlockCode" type="Node" parent="Node2D"]
 script = ExtResource("2_ewral")
-bsd = SubResource("Resource_iw7o0")
+block_script = SubResource("Resource_iw7o0")
 
 [node name="RigidBody2D" type="RigidBody2D" parent="."]
 
@@ -1141,10 +1141,10 @@ shape = SubResource("CircleShape2D_wymn4")
 
 [node name="BlockCode" type="Node" parent="RigidBody2D"]
 script = ExtResource("2_ewral")
-bsd = SubResource("Resource_37its")
+block_script = SubResource("Resource_37its")
 
 [node name="Counter" type="Node2D" parent="."]
 
 [node name="BlockCode" type="Node" parent="Counter"]
 script = ExtResource("2_ewral")
-bsd = SubResource("Resource_bw4t7")
+block_script = SubResource("Resource_bw4t7")


### PR DESCRIPTION
This is user facing in the Inspector. Exported properties appear capitalized in the Inspector so this will now figure as "Block Script" rather than "Bsd"