### PR TITLE
Add ‘On body entered’ entry block for Area2D and RigidBody2D

### DIFF
--- a/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
@@ -24,6 +24,8 @@ func generate_script_from_current_window(script_inherits: String = ""):
 
 	script += "var VAR_DICT := {}\n\n"
 
+	var init_func = InstructionTree.TreeNode.new("func _init():")
+
 	for entry_block in entry_blocks:
 		script += entry_block.get_entry_statement() + "\n"
 
@@ -38,5 +40,11 @@ func generate_script_from_current_window(script_inherits: String = ""):
 			script += to_append
 
 		script += "\n"
+
+		if entry_block.signal_name:
+			init_func.add_child(InstructionTree.TreeNode.new("{0}.connect(_on_{0})".format([entry_block.signal_name])))
+
+	if init_func.children:
+		script += InstructionTree.new().generate_text(init_func)
 
 	return script

--- a/addons/block_code/ui/blocks/entry_block/entry_block.gd
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.gd
@@ -2,6 +2,9 @@
 class_name EntryBlock
 extends StatementBlock
 
+## if non-empty, this block defines a callback that will be connected to the signal with this name
+@export var signal_name: String
+
 
 func _ready():
 	block_type = Types.BlockType.ENTRY
@@ -23,3 +26,9 @@ func get_entry_statement() -> String:
 		formatted_statement = formatted_statement.replace("{%s}" % pair[0], pair[1].get_string())
 
 	return formatted_statement
+
+
+func get_serialized_props() -> Array:
+	var props := super()
+	props.append_array(serialize_props(["signal_name"]))
+	return props

--- a/addons/block_code/ui/blocks/entry_block/entry_block.gd
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.gd
@@ -22,8 +22,4 @@ func get_entry_statement() -> String:
 	for pair in param_name_input_pairs:
 		formatted_statement = formatted_statement.replace("{%s}" % pair[0], pair[1].get_string())
 
-	# One line, should not have \n
-	if formatted_statement.find("\n") != -1:
-		push_error("Entry block has multiline statement.")
-
 	return formatted_statement

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -35,7 +35,7 @@ func _on_drag_drop_area_mouse_down():
 
 func get_serialized_props() -> Array:
 	var props := super()
-	props.append_array(serialize_props(["block_format", "statement"]))
+	props.append_array(serialize_props(["block_format", "statement", "variant_type"]))
 
 	var _param_input_strings: Dictionary = {}
 	for pair in param_name_input_pairs:

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -55,7 +55,11 @@ func get_string() -> String:
 	var snapped_block: ParameterBlock = get_snapped_block() as ParameterBlock
 	if snapped_block:
 		var generated_string = snapped_block.get_parameter_string()
-		return Types.cast(generated_string, snapped_block.variant_type, variant_type)
+		if Types.can_cast(snapped_block.variant_type, variant_type):
+			return Types.cast(generated_string, snapped_block.variant_type, variant_type)
+		else:
+			push_warning("No cast from %s to %s; using '%s' verbatim" % [snapped_block, variant_type, generated_string])
+			return generated_string
 
 	var text: String = get_plain_text()
 

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -348,7 +348,7 @@ static func get_built_in_categories(_class_name: String) -> Array[BlockCategory]
 	var class_cat: BlockCategory = category_from_property_list(prop_list, props, _class_name, Color.SLATE_GRAY)
 	block_list.append_array(class_cat.block_list)
 	class_cat.block_list = block_list
-	if props.size() > 0:
+	if block_list:
 		cats.append(class_cat)
 
 	return cats

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -83,11 +83,6 @@ static func get_general_categories() -> Array[BlockCategory]:
 	b.statement = "print({text})"
 	test_list.append(b)
 
-	b = BLOCKS["entry_block"].instantiate()
-	b.block_format = "On body enter [body: NODE_PATH]"
-	b.statement = "func _on_body_enter(body):"
-	test_list.append(b)
-
 	var test_category: BlockCategory = BlockCategory.new("Test", test_list, Color("9989df"))
 
 	# Signal
@@ -339,9 +334,26 @@ static func get_built_in_categories(_class_name: String) -> Array[BlockCategory]
 			props = ["modulate"]
 
 		"RigidBody2D":
-			# On body entered
+			for verb in ["entered", "exited"]:
+				var b = BLOCKS["entry_block"].instantiate()
+				b.block_format = "On [body: NODE_PATH] %s" % [verb]
+				# HACK: Blocks refer to nodes by path but the callback receives the node itself;
+				# convert to path
+				b.statement = "func _on_body_%s(_body: Node):\n\tvar body: NodePath = _body.get_path()" % [verb]
+				b.signal_name = "body_%s" % [verb]
+				block_list.append(b)
 
 			props = ["mass", "linear_velocity", "angular_velocity"]
+
+		"Area2D":
+			for verb in ["entered", "exited"]:
+				var b = BLOCKS["entry_block"].instantiate()
+				b.block_format = "On [body: NODE_PATH] %s" % [verb]
+				# HACK: Blocks refer to nodes by path but the callback receives the node itself;
+				# convert to path
+				b.statement = "func _on_body_%s(_body: Node2D):\n\tvar body: NodePath = _body.get_path()" % [verb]
+				b.signal_name = "body_%s" % [verb]
+				block_list.append(b)
 
 	var prop_list = ClassDB.class_get_property_list(_class_name, true)
 

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -300,7 +300,10 @@ static func category_from_property_list(property_list: Array, selected_props: Ar
 			if selected_property == prop.name:
 				found_prop = prop
 				break
-		block_list.append_array(property_to_blocklist(found_prop))
+		if found_prop:
+			block_list.append_array(property_to_blocklist(found_prop))
+		else:
+			push_warning("No property matching %s found in %s" % [selected_property, property_list])
 
 	return BlockCategory.new(p_name, block_list, p_color)
 


### PR DESCRIPTION
The block ‘compiles’ to a callback function, which needs to be connected
to the signal in question. To do this, add an additional code-generation
step that generates an _init() function to connect signals.

A more idiomatic approach would be to connect to the signals in the
_ready() function. This would involve merging additional code with the
user-supplied _ready() function, so is deferred for now. _init() works
fine.

https://phabricator.endlessm.com/T35510