### PR TITLE
Only show Block Code tab if a BlockCode node is selected

### DIFF
--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -46,7 +46,8 @@ func switch_script(block_code_node: BlockCode):
 	_picker.bsd_selected(bsd)
 	_title_bar.bsd_selected(bsd)
 	_block_canvas.bsd_selected(bsd)
-	block_code_tab.pressed.emit()
+	if block_code_node:
+		block_code_tab.pressed.emit()
 
 
 func save_script():


### PR DESCRIPTION
In 60e74e9a1ba00c7cf5d4ad91c8eb6ad815737ffb, MainPanel.switch_script was changed to update UI elements even if the block_code node is null, but it also switching to the Block Code tab in the editor in either case.

https://phabricator.endlessm.com/T35511